### PR TITLE
Fix missing package.json in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ USER node
 
 # Copy files
 COPY --from=node_modules /opt/html-to-pdf/node_modules/ node_modules/
+COPY package.json package.json
 COPY src/ src/
 
 CMD ["--experimental-top-level-await", "src/index.js"]


### PR DESCRIPTION
`package.json` is needed in the docker image to let NodeJS read the `type: module` that allows using ES modules.